### PR TITLE
Update Tests

### DIFF
--- a/test-queue.cpp
+++ b/test-queue.cpp
@@ -1,108 +1,114 @@
-//lang::CwC
+// lang::CwC
 
-#include <stdlib.h>
-#include <stdio.h>
 #include "object.h"
 #include "queue.h"
 #include "string.h"
+#include <stdio.h>
+#include <stdlib.h>
 
-void FAIL() {   exit(1);    }
-void OK(const char* m) { printf("%s: Test Success\n", m); }
-void t_true(bool p) { if (!p) FAIL(); }
-void t_false(bool p) { if (p) FAIL(); }
-
-//Test cases for the Queue & Object classes & member functions.
-void test_queue_object_classes(){
-    Queue* q = new Queue();
-    Queue* p = new Queue();
-    Object* o = new Object();
-    Object* o1 = new Object();
-
-    t_true(q->is_queue_empty());
-
-    q->enqueue(o);
-    t_false(q->is_queue_empty());
-
-    q->enqueue(o1);
-    //q is now [o1, o]
-
-    p->enqueue(o1);
-    //p now is [o1]
-    t_false(p->equals(q));
-
-    q->dequeue();
-    // q now is [o1]
-    t_true(p->equals(q));
-
-    q->enqueue(o);
-    //q now is [o, o1]
-
-    t_true(q->get_queue_length() == 2);
-
-    Object* peeked_q = q->peek(); // = Object o1
-    Object* peeked_p = p->peek(); // = Object o1
-
-    t_true(peeked_q->equals(peeked_p));
-    t_true(peeked_q->hash() == peeked_p->hash());
-
-    OK("Object Queue");
+void FAIL() { exit(1); }
+void OK(const char *m) { printf("%s: Test Success\n", m); }
+void t_true(bool p) {
+  if (!p)
+    FAIL();
+}
+void t_false(bool p) {
+  if (p)
+    FAIL();
 }
 
-//Test cases for the Queue & String classes & member functions.
-void test_queue_string_classes(){
-    Queue* q = new Queue();
-    Queue* p = new Queue();
-    String* s1 = new String("Howdy");
-    String* s2 = new String("Partner");
+// Test cases for the Queue & Object classes & member functions.
+void test_queue_object_classes() {
+  Queue *q = new Queue();
+  Queue *p = new Queue();
+  Object *o = new Object();
+  Object *o1 = new Object();
 
-    q->enqueue(s2);
-    t_false(q->is_queue_empty());
+  t_true(q->is_queue_empty());
 
-    q->enqueue(s1);
-    // q is now [s1, s2]
+  q->enqueue(o);
+  t_false(q->is_queue_empty());
 
-    p->enqueue(s1);
-    // p now is [s1]
-    t_false(p->equals(q));
+  q->enqueue(o1);
+  // q is now [o1, o]
 
-    q->dequeue();
-    // q now is [s1]
-    t_true(p->equals(q));
+  p->enqueue(o1);
+  // p now is [o1]
+  t_false(p->equals(q));
 
-    q->enqueue(s2);
-    // q now is [s2, s1]
+  q->dequeue();
+  // q now is [o1]
+  t_true(p->equals(q));
 
-    t_true(q->get_queue_length() == 2);
+  q->enqueue(o);
+  // q now is [o, o1]
 
-    Object* peeked_q = q->peek(); // = String s1
-    Object* peeked_p = p->peek(); // = String s1
+  t_true(q->get_queue_length() == 2);
 
-    t_true(peeked_q->equals(peeked_p));
-    t_true(peeked_q->hash() == peeked_p->hash());
+  Object *peeked_q = q->peek(); // = Object o1
+  Object *peeked_p = p->peek(); // = Object o1
 
-    OK("String Queue");
+  t_true(peeked_q->equals(peeked_p));
+  t_true(peeked_q->hash() == peeked_p->hash());
+
+  OK("Object Queue");
 }
 
-void test_string_class(){
-    String* s = new String("Hello ");
-    String* s1 = new String("World.");
-    String* s2 = new String("Hello World.");
-    String* s3 = new String("H");
-    String* s4 = s->concat(s1);
+// Test cases for the Queue & String classes & member functions.
+void test_queue_string_classes() {
+  Queue *q = new Queue();
+  Queue *p = new Queue();
+  String *s1 = new String("Howdy");
+  String *s2 = new String("Partner");
 
-    t_true(s4->equals(s2));
-    t_false(s->equals(s1));
+  q->enqueue(s2);
+  t_false(q->is_queue_empty());
 
-    t_true(s->compare(s1) == -1);
-    t_true(s2->compare(s3) == 1);
-    t_true(s2->compare(s4) == 0);
+  q->enqueue(s1);
+  // q is now [s1, s2]
 
-    OK("String");
+  p->enqueue(s1);
+  // p now is [s1]
+  t_false(p->equals(q));
+
+  q->dequeue();
+  // q now is [s1]
+  t_true(p->equals(q));
+
+  q->enqueue(s2);
+  // q now is [s2, s1]
+
+  t_true(q->get_queue_length() == 2);
+
+  Object *peeked_q = q->peek(); // = String s1
+  Object *peeked_p = p->peek(); // = String s1
+
+  t_true(peeked_q->equals(peeked_p));
+  t_true(peeked_q->hash() == peeked_p->hash());
+
+  OK("String Queue");
+}
+
+void test_string_class() {
+  String *s = new String("Hello ");
+  String *s1 = new String("World.");
+  String *s2 = new String("Hello World.");
+  String *s3 = new String("H");
+  String *s4 = s->concat(s1);
+
+  t_true(s4->equals(s2));
+  t_false(s->equals(s1));
+
+  t_true(s->compare(s1) == -1);
+  t_true(s2->compare(s3) == 1);
+  t_true(s2->compare(s4) == 0);
+
+  OK("String");
 }
 
 int main() {
-    test_queue_object_classes();
-    test_queue_string_classes();
-    test_string_class();
-    return 0;
+  test_queue_object_classes();
+  test_queue_string_classes();
+  test_string_class();
+  return 0;
 }

--- a/test-queue.cpp
+++ b/test-queue.cpp
@@ -3,19 +3,11 @@
 #include "object.h"
 #include "queue.h"
 #include "string.h"
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-void FAIL() { exit(1); }
 void OK(const char *m) { printf("%s: Test Success\n", m); }
-void t_true(bool p) {
-  if (!p)
-    FAIL();
-}
-void t_false(bool p) {
-  if (p)
-    FAIL();
-}
 
 // Test cases for the Queue & Object classes & member functions.
 void test_queue_object_classes() {
@@ -24,32 +16,32 @@ void test_queue_object_classes() {
   Object *o = new Object();
   Object *o1 = new Object();
 
-  t_true(q->is_queue_empty());
+  assert(q->is_queue_empty());
 
   q->enqueue(o);
-  t_false(q->is_queue_empty());
+  assert(!q->is_queue_empty());
 
   q->enqueue(o1);
   // q is now [o1, o]
 
   p->enqueue(o1);
   // p now is [o1]
-  t_false(p->equals(q));
+  assert(!p->equals(q));
 
   q->dequeue();
   // q now is [o1]
-  t_true(p->equals(q));
+  assert(p->equals(q));
 
   q->enqueue(o);
   // q now is [o, o1]
 
-  t_true(q->get_queue_length() == 2);
+  assert(q->get_queue_length() == 2);
 
   Object *peeked_q = q->peek(); // = Object o1
   Object *peeked_p = p->peek(); // = Object o1
 
-  t_true(peeked_q->equals(peeked_p));
-  t_true(peeked_q->hash() == peeked_p->hash());
+  assert(peeked_q->equals(peeked_p));
+  assert(peeked_q->hash() == peeked_p->hash());
 
   OK("Object Queue");
 }
@@ -62,29 +54,29 @@ void test_queue_string_classes() {
   String *s2 = new String("Partner");
 
   q->enqueue(s2);
-  t_false(q->is_queue_empty());
+  assert(!q->is_queue_empty());
 
   q->enqueue(s1);
   // q is now [s1, s2]
 
   p->enqueue(s1);
   // p now is [s1]
-  t_false(p->equals(q));
+  assert(!p->equals(q));
 
   q->dequeue();
   // q now is [s1]
-  t_true(p->equals(q));
+  assert(p->equals(q));
 
   q->enqueue(s2);
   // q now is [s2, s1]
 
-  t_true(q->get_queue_length() == 2);
+  assert(q->get_queue_length() == 2);
 
   Object *peeked_q = q->peek(); // = String s1
   Object *peeked_p = p->peek(); // = String s1
 
-  t_true(peeked_q->equals(peeked_p));
-  t_true(peeked_q->hash() == peeked_p->hash());
+  assert(peeked_q->equals(peeked_p));
+  assert(peeked_q->hash() == peeked_p->hash());
 
   OK("String Queue");
 }
@@ -96,12 +88,12 @@ void test_string_class() {
   String *s3 = new String("H");
   String *s4 = s->concat(s1);
 
-  t_true(s4->equals(s2));
-  t_false(s->equals(s1));
+  assert(s4->equals(s2));
+  assert(!s->equals(s1));
 
-  t_true(s->compare(s1) == -1);
-  t_true(s2->compare(s3) == 1);
-  t_true(s2->compare(s4) == 0);
+  assert(s->compare(s1) == -1);
+  assert(s2->compare(s3) == 1);
+  assert(s2->compare(s4) == 0);
 
   OK("String");
 }

--- a/test-queue.cpp
+++ b/test-queue.cpp
@@ -91,8 +91,8 @@ void test_string_class() {
   assert(s4->equals(s2));
   assert(!s->equals(s1));
 
-  assert(s->compare(s1) == -1);
-  assert(s2->compare(s3) == 1);
+  assert(s->compare(s1) < 0);
+  assert(s2->compare(s3) > 0);
   assert(s2->compare(s4) == 0);
 
   OK("String");


### PR DESCRIPTION
The diff for these changes is difficult to grok, but looking at it commit by commit will be the best way. I'll explain each change here as well.

## 🎨 Replace `crlf` with `lf` and run Google C++ autoformatter https://github.com/spencerlachance/cs4500a1part2/commit/357de30386e0980bcbc71fdf63c3c8e44f4f8018
Highly recommend developing on the login.css.neu.edu linux boxes or linux virtual desktop. Personally, I use `nvim` with `google/vim-codefmt` for this. This will standardize your file structure with the rest of the class, and the formatter let's your not worry about formatting. My formatter runs on save so no avoiding this diff, tried to pull it into it's own commit to make it easier to review.
There were no behavior changes in this commit.

## 🚥 Use `assert` instead of `t_true` and `t_false` https://github.com/spencerlachance/cs4500a1part2/pull/12/commits/3f19e5770ebd7be3a955a2bccc1beccb8590d7cc
When a test fails with `t_true` or `t_false` the only way to tell which failed is to start commenting out sections of the test. Using assert prints an error which includes the comparison which failed. This makes debugging failing tests much more efficient.
e.g. `Assertion failed: (s->compare(s1) == -1), function test_string_class, file test_queue.cpp, line 94.`

## 〰️  String Compare test https://github.com/spencerlachance/cs4500a1part2/pull/12/commits/a37918e1663274dcc8aec76c7dc562f9867c7809
Your `String` compare test looks for specific values of `1` and `-1`, however, the C `stdlib` function `strcmp` returns values of `< 0` and `> 0`. Since this is the most stable function to implement this behavior, your API for `String::compare` should match `strcmp`. Additionally, this is the API that will hopefully become [the class standard](https://piazza.com/class/k51bluky59n2jr?cid=345).
https://www.tutorialspoint.com/c_standard_library/c_function_strcmp.htm